### PR TITLE
Fix executor replacer not working

### DIFF
--- a/src/main/kotlin/tech/sethi/pebbles/flexiblecommands/command/CommandRegistry.kt
+++ b/src/main/kotlin/tech/sethi/pebbles/flexiblecommands/command/CommandRegistry.kt
@@ -133,6 +133,10 @@ object CommandRegistry {
 
             when {
                 key == "baseCommand" -> command.baseCommand
+                key == "executor" -> {
+                    val player = source.player
+                    if (player != null) player.name.string else ""
+                }
                 key.startsWith("custom:") -> {
                     val parts = key.removePrefix("custom:").split(":")
                     val logicKey = parts[0]


### PR DESCRIPTION
The executor replacer wasn't working when running an alias command as console or when running a command as a player. Also I apologize ahead of time if this isn't the format you want for handling nullability, not super familiar with the Kotlin specific syntax for it.